### PR TITLE
Use the correct icon for launcher

### DIFF
--- a/zotero_installer.sh
+++ b/zotero_installer.sh
@@ -126,7 +126,7 @@ echo "[Desktop Entry]
 Name=Zotero
 Comment=Open-source reference manager (standalone version)
 Exec=$DEST/$DEST_FOLDER/zotero
-Icon=accessories-dictionary
+Icon=$DEST/$DEST_FOLDER/zotero/chrome/icons/default/default48.png
 Type=Application
 StartupNotify=true" > $MENU_PATH
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
The script has been using the dictionary icon rather than the Zotero icon.
