### PR TITLE
fix duplicate /zotero folder in icon path for .desktop file

### DIFF
--- a/zotero_installer.sh
+++ b/zotero_installer.sh
@@ -126,7 +126,7 @@ echo "[Desktop Entry]
 Name=Zotero
 Comment=Open-source reference manager (standalone version)
 Exec=$DEST/$DEST_FOLDER/zotero
-Icon=$DEST/$DEST_FOLDER/zotero/chrome/icons/default/default48.png
+Icon=$DEST/$DEST_FOLDER/chrome/icons/default/default48.png
 Type=Application
 StartupNotify=true" > $MENU_PATH
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
The generated `zotero.desktop` file currently sets its icon as: `$DEST_FOLDER/zotero/chrome/...`, which isn't quite right. On a local install, for example, that becomes: 

`/home/user/zotero/zotero/chrome/icons/default/default48.png`. 

Instead, it should be 

`/home/user/zotero/chrome/icons/default/default48.png`. 